### PR TITLE
Add Google sign-in onboarding flow

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import { GoogleOAuthProvider } from "@react-oauth/google";
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <GoogleOAuthProvider clientId="YOUR_GOOGLE_CLIENT_ID">
+    <App />
+  </GoogleOAuthProvider>
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@radix-ui/react-toggle": "^1.1.3",
         "@radix-ui/react-toggle-group": "^1.1.3",
         "@radix-ui/react-tooltip": "^1.2.0",
+        "@react-oauth/google": "^0.12.2",
         "@tanstack/react-query": "^5.60.5",
         "@types/memoizee": "^0.4.12",
         "class-variance-authority": "^0.7.1",
@@ -2700,6 +2701,16 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.12.2.tgz",
+      "integrity": "sha512-d1GVm2uD4E44EJft2RbKtp8Z1fp/gK8Lb6KHgs3pHlM0PxCXGLaq8LLYQYENnN4xPWO1gkL4apBtlPKzpLvZwg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/@replit/vite-plugin-cartographer": {
       "version": "0.2.7",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@radix-ui/react-toggle": "^1.1.3",
     "@radix-ui/react-toggle-group": "^1.1.3",
     "@radix-ui/react-tooltip": "^1.2.0",
+    "@react-oauth/google": "^0.12.2",
     "@tanstack/react-query": "^5.60.5",
     "@types/memoizee": "^0.4.12",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary
- integrate Google OAuth provider
- add Google sign-in step before selecting interests
- move interest selection to second step

## Testing
- `npm run check` *(fails: History.tsx and server files type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68498f801cf4832cb559effeaeede216